### PR TITLE
Implement loan repayment functionality for users

### DIFF
--- a/src/banking/Administrator.java
+++ b/src/banking/Administrator.java
@@ -32,5 +32,49 @@ public class Administrator extends User {
         }
     }
     
+    public void showAllLoansWithStatus(Map<String, List<Transaction>> allTransactions) {
+        System.out.println("\n--- Pending Loans ---");
+        for (Map.Entry<String, List<Transaction>> entry : allTransactions.entrySet()) {
+            String username = entry.getKey();
+            for (Transaction t : entry.getValue()) {
+                if (t instanceof Loan loan && !loan.isApproved()) {
+                    System.out.printf("(%s): %s: $%.2f [ID: %s] [Approved=%b, Paid=%.2f/%.2f]\n",
+                        username, loan.getDescription(), loan.getAmount(), loan.getTransactionID(), 
+                        loan.isApproved(), loan.getAmountPaid(), loan.getAmount());
+                }
+            }
+        }
+    
+        System.out.println("\n--- Approved Loans ---");
+        for (Map.Entry<String, List<Transaction>> entry : allTransactions.entrySet()) {
+            String username = entry.getKey();
+            for (Transaction t : entry.getValue()) {
+                if (t instanceof Loan loan && loan.isApproved()) {
+                    System.out.printf("(%s): %s: $%.2f [ID: %s] [Approved=%b, Paid=%.2f/%.2f]\n",
+                        username, loan.getDescription(), loan.getAmount(), loan.getTransactionID(), 
+                        loan.isApproved(), loan.getAmountPaid(), loan.getAmount());
+                }
+            }
+        }
+    }
+    
+    public boolean approveLoanById(String transactionID, Map<String, List<Transaction>> allTransactions) {
+        for (Map.Entry<String, List<Transaction>> entry : allTransactions.entrySet()) {
+            List<Transaction> txList = entry.getValue();
+            for (Transaction t : txList) {
+                if (t instanceof Loan loan && t.getTransactionID().equals(transactionID)) {
+                    if (loan.isApproved()) {
+                        System.out.println("This loan has already been approved.");
+                        return false;
+                    }
+                    loan.approve();
+                    System.out.println("Loan approved successfully.");
+                    return true;
+                }
+            }
+        }
+        System.out.println("No matching loan found for the given ID.");
+        return false;
+    }
     
 }

--- a/src/banking/Administrator.java
+++ b/src/banking/Administrator.java
@@ -57,8 +57,9 @@ public class Administrator extends User {
         }
     }
     
-    public boolean approveLoanById(String transactionID, Map<String, List<Transaction>> allTransactions) {
+    public boolean approveLoanById(String transactionID, Map<String, List<Transaction>> allTransactions, Database db) {
         for (Map.Entry<String, List<Transaction>> entry : allTransactions.entrySet()) {
+            String username = entry.getKey();
             List<Transaction> txList = entry.getValue();
             for (Transaction t : txList) {
                 if (t instanceof Loan loan && t.getTransactionID().equals(transactionID)) {
@@ -67,7 +68,11 @@ public class Administrator extends User {
                         return false;
                     }
                     loan.approve();
-                    System.out.println("Loan approved successfully.");
+                    User loanUser = db.getUserData(username);
+                    if (loanUser != null) {
+                        loanUser.depositSilently(loan.getAmount());
+                        System.out.println("Loan approved successfully.");
+                    }
                     return true;
                 }
             }

--- a/src/banking/Database.java
+++ b/src/banking/Database.java
@@ -117,29 +117,34 @@ public class Database implements Serializable{
     }
     
     public HashMap<User, Transaction> recallTransaction(String transactionID) {
-    	HashMap<String, Transaction> usersInfluenced = new HashMap<>();
-    	for (Map.Entry<String, List<Transaction>> entry : mapToTransactions.entrySet()) {
-    		String username = entry.getKey();
-    		List<Transaction> transactionHistory = entry.getValue();
-
-			transactionHistory.removeIf(t -> {
-			    if (t.getTransactionID().equals(transactionID)) {
-			        Double amount = t.getAmount();
-			        usersInfluenced.put(username, t);
-			        return true;
-			    }
-			    return false;
-			});
-    	    
-    	}
-    	HashMap<User, Transaction> usersToReturn = new HashMap<>();
-    	for (Map.Entry<String, Transaction> entry : usersInfluenced.entrySet()) {
-    		String username = entry.getKey();
-    		Transaction transaction = entry.getValue();
-    		User user = getUserData(username);
-    		usersToReturn.put(user, transaction);
-    	}
-    	return usersToReturn;
+        HashMap<User, Transaction> usersToReturn = new HashMap<>();
+        //iterate through the map of transactions
+        for (Map.Entry<String, List<Transaction>> entry: mapToTransactions.entrySet()) {
+            String username = entry.getKey();
+            List<Transaction> transactionHistory = entry.getValue();
+            for (Transaction t : new ArrayList<>(transactionHistory)) {
+                if (t.getTransactionID().equals(transactionID)) {
+                    //loan-specific checks
+                    if (t instanceof Loan loan) {
+                        if (!loan.isApproved()) {
+                            System.out.println("Cannot recall an unapproved loan!");
+                            return new HashMap<>();
+                        }
+                        if (loan.isPaidOff()) {
+                            System.out.println("Cannot recall a fully paid loan!");
+                            return new HashMap<>();
+                        }
+                    }
+                    transactionHistory.remove(t);
+                    User user = getUserData(username);
+                    if (user != null) {
+                        usersToReturn.put(user, t);
+                    }
+                    break;
+                }
+            }
+        }
+        return usersToReturn;
     }
     
     

--- a/src/banking/Database.java
+++ b/src/banking/Database.java
@@ -130,10 +130,14 @@ public class Database implements Serializable{
                             System.out.println("Cannot recall an unapproved loan!");
                             return new HashMap<>();
                         }
-                        if (loan.isPaidOff()) {
-                            System.out.println("Cannot recall a fully paid loan!");
+                        if (loan.isPaidOff() || loan.getAmountPaid() > 0) {
+                            System.out.println("Cannot recall a loan that has already been partially or fully repaid!");
                             return new HashMap<>();
                         }
+                    }
+                    if (t.getDescription().toLowerCase().contains("loan repayment")) {
+                        System.out.println("Loan repayment transactions cannot be recalled!");
+                        return new HashMap<>();
                     }
                     transactionHistory.remove(t);
                     User user = getUserData(username);

--- a/src/banking/Database.java
+++ b/src/banking/Database.java
@@ -1,16 +1,9 @@
 package banking;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-import java.security.MessageDigest;
-import banking.Transaction;
 
 
 public class Database implements Serializable{
@@ -158,6 +151,13 @@ public class Database implements Serializable{
         return allTransactions;
     }
 
-
+    //returns the full map of transactions by username
+    public Map<String, List<Transaction>> getAllTransactionMap() {
+        return mapToTransactions;
+    }
+    
+    public void saveAllTransactions() {
+        fileSystem.saveTransactionsToFile(mapToTransactions);
+    }
     
 }

--- a/src/banking/Loan.java
+++ b/src/banking/Loan.java
@@ -1,0 +1,37 @@
+package banking;
+
+public class Loan extends Transaction {
+    private boolean isApproved;
+    private boolean isPaidOff;
+    private double amountPaid;
+
+    public Loan(double amount, String description) {
+        super(amount, description);
+        this.isApproved = false;
+        this.isPaidOff = false;
+        this.amountPaid = 0.0;
+    }
+
+    public Loan(double amount, String description, String transactionID) {
+        super(amount, description, transactionID);
+        this.isApproved = false;
+        this.isPaidOff = false;
+        this.amountPaid = 0.0;
+    }
+
+    public boolean isApproved() {
+        return isApproved;
+    }
+
+    public boolean isPaidOff() {
+        return isPaidOff;
+    }
+
+    public double getAmountPaid() {
+        return amountPaid;
+    }
+
+    public void approve() {
+        this.isApproved = true;
+    }
+}

--- a/src/banking/Loan.java
+++ b/src/banking/Loan.java
@@ -34,4 +34,15 @@ public class Loan extends Transaction {
     public void approve() {
         this.isApproved = true;
     }
+
+    public boolean makeRepayment(double amount) {
+        if (!isApproved || isPaidOff || amount <= 0) return false;
+    
+        amountPaid += amount;
+        if (amountPaid >= getAmount()) {
+            isPaidOff = true;
+        }
+        return true;
+    }
+    
 }

--- a/src/banking/Menu.java
+++ b/src/banking/Menu.java
@@ -324,18 +324,28 @@ public class Menu {
         return false;
     }
     
+
     public void recallTransaction() {
-        String transactionID = keyboardInput.getSafeInput("Which transaction would you like to reacall? (type transaction id): ","",Function.identity());
+        String transactionID = keyboardInput.getSafeInput("Which transaction would you like to recall? (type transaction id): ","",Function.identity());
+        boolean idExists = dataHandler.getAllTransactions().stream().anyMatch(t -> t.getTransactionID().equals(transactionID));
         HashMap<User, Transaction> usersInfluenced = dataHandler.recallTransaction(transactionID);
+
         if (usersInfluenced.isEmpty()) {
-    		System.out.println("No matching transaction found for the given ID!");
-    		return ;
-    	}
+            //match found but recall was not allowed by rules, do nothing
+            if (idExists) {
+                return;
+            } 
+            //no match found, return error message
+            else {
+                System.out.println("No matching transaction found for the given ID!");
+                return;
+            }
+        }
         new Administrator(this.activeUser).recallTransactions(usersInfluenced);
         dataHandler.updateUserInfo();
-
+        dataHandler.saveAllTransactions();
     }
-    
+
     public void printAllTransactions() {
         List<Transaction> transactionList = dataHandler.getAllTransactions();
         new Administrator(this.activeUser).printAllTransactions(transactionList);

--- a/src/banking/Menu.java
+++ b/src/banking/Menu.java
@@ -359,7 +359,7 @@ public class Menu {
         String loanIdToApprove = keyboardInput.getSafeInput("\nEnter the Loan ID to approve (or type 'exit' to exit):", "Invalid input.", Function.identity());
 
         if (!loanIdToApprove.equalsIgnoreCase("exit")) {
-            boolean approved = admin.approveLoanById(loanIdToApprove, allTransactions);
+            boolean approved = admin.approveLoanById(loanIdToApprove, allTransactions, dataHandler);
             if (approved) {
                 dataHandler.updateUserInfo();
                 dataHandler.saveAllTransactions();

--- a/src/banking/User.java
+++ b/src/banking/User.java
@@ -174,10 +174,10 @@ public class User implements Serializable {
         double amount = pastTransaction.getAmount();
         String newDescription = pastTransaction.getDescription() + " [RECALLED]";
 
-        if (pastTransaction instanceof Loan loan) {
-            //revert only unpaid portion
-            amount = loan.getAmount() - loan.getAmountPaid();
-        }         
+        // if (pastTransaction instanceof Loan loan) {
+        //     //revert only unpaid portion
+        //     amount = loan.getAmount() - loan.getAmountPaid();
+        // }         
 
         this.balance -= amount;
         return new Transaction(-amount, newDescription);
@@ -211,5 +211,33 @@ public class User implements Serializable {
         System.out.println("Loan request submitted for $" + String.format("%.2f", amount));
         return loan;
     }    
+
+    //Repay loan
+    public Transaction repayLoan(Loan loan, double amount) {
+        if (!loan.isApproved()) {
+            System.out.println("Cannot repay an unapproved loan.");
+            return null;
+        }
+        if (loan.isPaidOff()) {
+            System.out.println("This loan has already been paid off.");
+            return null;
+        }
+        if (amount <= 0) {
+            System.out.println("Invalid amount for repayment.");
+            return null;
+        }
+        if (this.balance < amount) {
+            System.out.println("Insufficient balance for repayment.");
+            return null;
+        }
+        if (loan.getAmountPaid() + amount > loan.getAmount()) {
+            System.out.println("Repayment exceeds remaining loan amount.");
+            return null;
+        }
+        this.balance -= amount;
+        loan.makeRepayment(amount);
+        System.out.println("Repayment successful.");
+        return new Transaction(-amount, "Loan repayment - " + loan.getDescription());
+    }
     
 }

--- a/src/banking/User.java
+++ b/src/banking/User.java
@@ -170,14 +170,18 @@ public class User implements Serializable {
         return new Transaction(amount, "Transfer from " + senderName + " - " + description, transactionID);
     }
     
-    public Transaction recallTransaction(Transaction pastTransaction ) {
-    	Double amount = pastTransaction.getAmount();
-    	String newDescription = pastTransaction.getDescription()+" [RECALLED]";
-    	
-    	this.balance -= amount;
-    	return new Transaction(-amount, newDescription);
-    	
-    }
+    public Transaction recallTransaction(Transaction pastTransaction) {
+        double amount = pastTransaction.getAmount();
+        String newDescription = pastTransaction.getDescription() + " [RECALLED]";
+
+        if (pastTransaction instanceof Loan loan) {
+            //revert only unpaid portion
+            amount = loan.getAmount() - loan.getAmountPaid();
+        }         
+
+        this.balance -= amount;
+        return new Transaction(-amount, newDescription);
+    }   
 
     //Request statement
     public void printStatement(List<Transaction> transactions) {
@@ -187,7 +191,7 @@ public class User implements Serializable {
                 if (t != null) {
                     String extra = "";
                     if (t instanceof Loan loan) {
-                        extra = String.format(" [Loan: Approved=%b, Paid=%.2f/%.2f]",
+                        extra = String.format(" [Approved=%b, Paid=%.2f/%.2f]",
                             loan.isApproved(), loan.getAmountPaid(), loan.getAmount());
                     }
                     System.out.printf("[%s] %s: $%.2f%s\n", t.getDate(), t.getDescription(), t.getAmount(), extra);

--- a/src/banking/User.java
+++ b/src/banking/User.java
@@ -165,13 +165,30 @@ public class User implements Serializable {
     //Request statement
     public void printStatement(List<Transaction> transactions) {
         System.out.println("\n--- Account Statement ---");
-        if(transactions != null) {
+        if (transactions != null) {
             for (Transaction t : transactions) {
-                System.out.printf("[%s] %s: $%.2f\n", 
-                    t.getDate(), t.getDescription(), t.getAmount());
+                if (t != null) {
+                    String extra = "";
+                    if (t instanceof Loan loan) {
+                        extra = String.format(" [Loan: Approved=%b, Paid=%.2f/%.2f]",
+                            loan.isApproved(), loan.getAmountPaid(), loan.getAmount());
+                    }
+                    System.out.printf("[%s] %s: $%.2f%s\n", t.getDate(), t.getDescription(), t.getAmount(), extra);
+                }
             }
         }
         System.out.printf("Current Balance: $%.2f\n", balance);
     }
+
+    //Request loan
+    public Loan requestLoan(double amount, String reason) {
+        if (amount <= 0) {
+            System.out.println("Loan amount must be positive.");
+            return null;
+        }
+        Loan loan = new Loan(amount, "Loan request - " + reason);
+        System.out.println("Loan request submitted for $" + String.format("%.2f", amount));
+        return loan;
+    }    
     
 }

--- a/src/banking/User.java
+++ b/src/banking/User.java
@@ -123,6 +123,13 @@ public class User implements Serializable {
     	return null;
     }
 
+    //deposit silently without transaction record or printout
+    public void depositSilently(double amount) {
+        if (amount > 0) {
+            this.balance += amount;
+        }
+    }
+
     //withdraw amount
     public Transaction withdraw(double amount) {
     	if (amount > 0 && balance >= amount) {

--- a/src/banking/User.java
+++ b/src/banking/User.java
@@ -226,18 +226,18 @@ public class User implements Serializable {
             System.out.println("Invalid amount for repayment.");
             return null;
         }
-        if (this.balance < amount) {
+        double remaining = loan.getAmount() - loan.getAmountPaid();
+        if (this.balance < Math.min(amount, remaining)) {
             System.out.println("Insufficient balance for repayment.");
             return null;
         }
-        if (loan.getAmountPaid() + amount > loan.getAmount()) {
-            System.out.println("Repayment exceeds remaining loan amount.");
-            return null;
-        }
-        this.balance -= amount;
-        loan.makeRepayment(amount);
-        System.out.println("Repayment successful.");
-        return new Transaction(-amount, "Loan repayment - " + loan.getDescription());
+
+        double repayAmount = Math.min(amount, remaining);
+        this.balance -= repayAmount;
+        loan.makeRepayment(repayAmount);
+        System.out.printf("Repayment successful. Repaid: $%.2f%n", repayAmount);
+
+        return new Transaction(-repayAmount, "Loan repayment - " + loan.getDescription());
     }
     
 }

--- a/src/tests/LoanTests.java
+++ b/src/tests/LoanTests.java
@@ -1,0 +1,67 @@
+package tests;
+
+import banking.*;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+
+public class LoanTests {
+
+    private Database db;
+    private User user;
+    private Administrator admin;
+
+    @BeforeEach
+    void setUp() {
+        db = new Database();
+        user = new User("loanUser", Authenticator.hashPassword("pass123"), 0.0);
+        db.createUser(user);
+        admin = new Administrator(user);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.deleteUser("loanUser");
+    }
+
+    @Test
+    void testLoanRequestIsRecorded() {
+        Loan loan = user.requestLoan(200.0, "New Laptop");
+        assertNotNull(loan);
+        assertFalse(loan.isApproved());
+        db.addUserTransaction(user.getUsername(), loan);
+
+        List<Transaction> tx = db.getUserTransaction(user.getUsername());
+        assertEquals(1, tx.size());
+        assertTrue(tx.get(0) instanceof Loan);
+        assertEquals(200.0, tx.get(0).getAmount());
+    }
+
+    @Test
+    void testLoanApprovalIncreasesBalance() {
+        Loan loan = user.requestLoan(300.0, "Tuition");
+        db.addUserTransaction(user.getUsername(), loan);
+
+        Map<String, List<Transaction>> allTx = db.getAllTransactionMap();
+        boolean success = admin.approveLoanById(loan.getTransactionID(), allTx, db);
+
+        assertTrue(success);
+        assertEquals(300.0, db.getUserData(user.getUsername()).getBalance());
+    }
+
+    @Test
+    void testLoanCannotBeApprovedTwice() {
+        Loan loan = user.requestLoan(150.0, "Emergency");
+        db.addUserTransaction(user.getUsername(), loan);
+
+        Map<String, List<Transaction>> allTx = db.getAllTransactionMap();
+        boolean firstApproval = admin.approveLoanById(loan.getTransactionID(), allTx, db);
+        boolean secondApproval = admin.approveLoanById(loan.getTransactionID(), allTx, db);
+
+        assertTrue(firstApproval);
+        assertFalse(secondApproval);
+    }
+}

--- a/src/tests/UserTests.java
+++ b/src/tests/UserTests.java
@@ -3,6 +3,7 @@ package tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import banking.Database;
+import banking.Loan;
 import banking.Transaction;
 import banking.User;
 import banking.Authenticator;
@@ -225,6 +227,65 @@ public class UserTests {
         assertTrue(targetTransactions.get(0).getDescription().contains("Issuer"));
         database.deleteUser("Issuer");
         database.deleteUser("Target");
+    }
+
+    @Test
+    void testSuccessfulLoanRepayment() throws Exception {
+        User testUser = new User("LoanPayer", Authenticator.hashPassword("password"), 500.0);
+        database.createUser(testUser);
+
+        Loan loan = new Loan(200.0, "Loan request - laptop");
+        loan.approve();
+        Transaction loanTx = loan;
+        database.addUserTransaction(testUser.getUsername(), loanTx);
+
+        Transaction repayment = testUser.repayLoan(loan, 150.0);
+        assertNotNull(repayment);
+        assertEquals(350.0, testUser.getBalance(), 0.01);
+        assertEquals(150.0, loan.getAmountPaid(), 0.01);
+        assertFalse(loan.isPaidOff());
+
+        Transaction finalRepayment = testUser.repayLoan(loan, 50.0);
+        assertNotNull(finalRepayment);
+        assertTrue(loan.isPaidOff());
+        assertEquals(300.0, testUser.getBalance(), 0.01);
+        database.deleteUser("LoanPayer");
+    }
+
+    @Test
+    void testRepaymentFailsForUnapprovedLoan() throws Exception {
+        User testUser = new User("UnapprovedLoanUser", Authenticator.hashPassword("password"), 500.0);
+        database.createUser(testUser);
+
+        Loan loan = new Loan(200.0, "Loan request - book");
+        Transaction repayment = testUser.repayLoan(loan, 100.0);
+
+        assertNull(repayment);
+        assertEquals(500.0, testUser.getBalance(), 0.01);
+        database.deleteUser("UnapprovedLoanUser");
+    }
+
+    @Test
+    void testOverRepaymentIsCapped() throws Exception {
+        User testUser = new User("Overpayer", Authenticator.hashPassword("password"), 500.0);
+        database.createUser(testUser);
+
+        Loan loan = new Loan(100.0, "Loan request - gift card");
+        loan.approve();
+        database.addUserTransaction(testUser.getUsername(), loan);
+
+        Transaction partialRepayment = testUser.repayLoan(loan, 80.0);
+        assertNotNull(partialRepayment);
+        assertEquals(420.0, testUser.getBalance(), 0.01);
+        assertEquals(80.0, loan.getAmountPaid(), 0.01);
+        assertFalse(loan.isPaidOff());
+
+        Transaction cappedRepayment = testUser.repayLoan(loan, 50.0);
+        assertNotNull(cappedRepayment);
+        assertEquals(400.0, testUser.getBalance(), 0.01);
+        assertEquals(100.0, loan.getAmountPaid(), 0.01);
+        assertTrue(loan.isPaidOff());
+        database.deleteUser("Overpayer");
     }
 
 }


### PR DESCRIPTION
Users now have a "Repay Loan" option to view all their requested loans.
Each repayment transaction deducts from their current balance.
Loan repayment progress is reflected in both the user's personal records and the admin's "Review All Loans" list.

Note: To keep the code clean and reduce potential bugs, admins are restricted to only recalling loans that are **approved and unpaid**.
They cannot recall unapproved loan requests, loans that have begun repayment, and any repayment transactions made by users.
I have implemented comprehensive error messages for all related actions.

Test cases will be added soon.